### PR TITLE
Feature/missing consumer operators

### DIFF
--- a/Pipeline.xcodeproj/project.pbxproj
+++ b/Pipeline.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8E56E6D31D2613FD009182DF /* TestMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E56E6D21D2613FD009182DF /* TestMocks.swift */; };
 		8E57D1001CF516FD00EDAF4A /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E57D0F01CF516FD00EDAF4A /* JSONTests.swift */; };
 		8E57D1011CF516FD00EDAF4A /* JSONTransformers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E57D0F11CF516FD00EDAF4A /* JSONTransformers.swift */; };
 		8E57D1021CF516FD00EDAF4A /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E57D0F21CF516FD00EDAF4A /* Logger.swift */; };
@@ -63,6 +64,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8E56E6D21D2613FD009182DF /* TestMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMocks.swift; sourceTree = "<group>"; };
 		8E57D0F01CF516FD00EDAF4A /* JSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
 		8E57D0F11CF516FD00EDAF4A /* JSONTransformers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONTransformers.swift; sourceTree = "<group>"; };
 		8E57D0F21CF516FD00EDAF4A /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 				8EE644671CE8639500403EFC /* animals.json */,
 				8EE6447A1CE929EB00403EFC /* user.json */,
 				8EE644561CE7AEA500403EFC /* Info.plist */,
+				8E56E6D21D2613FD009182DF /* TestMocks.swift */,
 			);
 			path = PipelineTests;
 			sourceTree = "<group>";
@@ -376,6 +379,7 @@
 				8E57D1331CF5235E00EDAF4A /* TransformerOperatorTests.swift in Sources */,
 				8E57D10B1CF516FD00EDAF4A /* Timer.swift in Sources */,
 				8E57D1021CF516FD00EDAF4A /* Logger.swift in Sources */,
+				8E56E6D31D2613FD009182DF /* TestMocks.swift in Sources */,
 				8E57D1091CF516FD00EDAF4A /* Threading.swift in Sources */,
 				8E57D1041CF516FD00EDAF4A /* NSFileManagerTransformers.swift in Sources */,
 				8E57D1311CF51FDE00EDAF4A /* ProducerOperatorTests.swift in Sources */,

--- a/Pipeline/Consumable/ConsumableOperators.swift
+++ b/Pipeline/Consumable/ConsumableOperators.swift
@@ -25,6 +25,16 @@ public func |> <S: ConsumableType, NewOutput>(lhs: S, rhs: S.OutputType throws -
     return ConsumablePipeline(head: lhs).then(resultFunction)
 }
 
+public func |> <T: TransformerType>(lhs: ConsumablePipeline<T.InputType>, rhs: T) -> ConsumablePipeline<T.OutputType>  {
+    
+    return lhs.then(rhs)
+}
+
+public func |> <T, U>(lhs: ConsumablePipeline<T>, rhs: T -> U) -> ConsumablePipeline<U>  {
+    
+    return lhs.then(rhs)
+}
+
 public func |> <S: ConsumableType, C: ConsumerType where S.OutputType == C.InputType>(lhs: S, rhs: C) -> Pipeline  {
     
     return ConsumablePipeline(head: lhs).finally(rhs)

--- a/Pipeline/Consumable/ConsumableOperators.swift
+++ b/Pipeline/Consumable/ConsumableOperators.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+// Creation
+
 public func |> <S: ConsumableType, T: TransformerType where S.OutputType == T.InputType>(lhs: S, rhs: T) -> ConsumablePipeline<T.OutputType>  {
     
     return ConsumablePipeline(head: lhs).then(rhs)
@@ -25,6 +27,8 @@ public func |> <S: ConsumableType, NewOutput>(lhs: S, rhs: S.OutputType throws -
     return ConsumablePipeline(head: lhs).then(resultFunction)
 }
 
+// Chaining
+
 public func |> <T: TransformerType>(lhs: ConsumablePipeline<T.InputType>, rhs: T) -> ConsumablePipeline<T.OutputType>  {
     
     return lhs.then(rhs)
@@ -34,6 +38,15 @@ public func |> <T, U>(lhs: ConsumablePipeline<T>, rhs: T -> U) -> ConsumablePipe
     
     return lhs.then(rhs)
 }
+
+public func |> <Input, NewOutput>(lhs: ConsumablePipeline<Input>, rhs: Input throws -> NewOutput) -> ConsumablePipeline<Result<NewOutput>>  {
+    
+    let resultFunction = map(rhs)
+    
+    return lhs.then(resultFunction)
+}
+
+// Finally
 
 public func |> <S: ConsumableType, C: ConsumerType where S.OutputType == C.InputType>(lhs: S, rhs: C) -> Pipeline  {
     
@@ -54,3 +67,4 @@ public func |> <O>(lhs: ConsumablePipeline<O>, rhs: O -> Void) -> Pipeline  {
     
     return lhs.finally(rhs)
 }
+

--- a/Pipeline/Producer/ProducerOperators.swift
+++ b/Pipeline/Producer/ProducerOperators.swift
@@ -8,22 +8,15 @@
 
 import Foundation
 
+// Creation
 
 public func |> <P: ProducerType, U: TransformerType where P.OutputType == U.InputType>(lhs: P, rhs: U) -> ProducerPipeline<U.OutputType>  {
     
     return ProducerPipeline(head: lhs).then(rhs)
 }
-
 public func |> <P: ProducerType, U>(lhs: P, rhs: P.OutputType -> U) -> ProducerPipeline<U>  {
     
-    let pipe = ProducerPipeline(head: lhs)
-    
-    return pipe.then(rhs)
-}
-
-public func |> <O, T where T: TransformerType, O == T.InputType>(lhs: ProducerPipeline<O>, rhs: T) -> ProducerPipeline<T.OutputType>  {
-    
-    return lhs.then(rhs)
+    return ProducerPipeline(head: lhs).then(rhs)
 }
 
 public func |> <V, T: TransformerType where V == T.InputType>(lhs: () -> V, rhs: T) -> ProducerPipeline<T.OutputType>  {
@@ -40,10 +33,26 @@ public func |> <V, T>(lhs: () -> V, rhs: V -> T) -> ProducerPipeline<T>  {
     return ProducerPipeline(head: thunkProducer).then(rhs)
 }
 
+// Chaining
+
+public func |> <O, T where T: TransformerType, O == T.InputType>(lhs: ProducerPipeline<O>, rhs: T) -> ProducerPipeline<T.OutputType>  {
+    
+    return lhs.then(rhs)
+}
+
 public func |> <O, C>(lhs: ProducerPipeline<O>, rhs: O -> C) -> ProducerPipeline<C>  {
     
     return lhs.then(rhs)
 }
+
+public func |> <Input, NewOutput>(lhs: ProducerPipeline<Input>, rhs: Input throws -> NewOutput) -> ProducerPipeline<Result<NewOutput>>  {
+    
+    let resultFunction = map(rhs)
+    
+    return lhs.then(resultFunction)
+}
+
+// Finally
 
 public func |> <P: ProducerType, C: ConsumerType where C.InputType == P.OutputType>(lhs: P, rhs: C) -> Producible  {
     

--- a/Pipeline/Transformer/Transformer.swift
+++ b/Pipeline/Transformer/Transformer.swift
@@ -24,16 +24,16 @@ public final class AnyTransformer<T, U>: TransformerType  {
     
     public typealias OutputType = U
     
-    public var consumer: (OutputType -> Void)?
+    public var consumer: (U -> Void)?
     
-    public let transform: InputType -> OutputType
+    public let transform: T -> U
     
-    public init(transform: InputType -> OutputType) {
+    public init(transform: T -> U) {
         
         self.transform = transform
     }
     
-    public func consume(input: InputType) {
+    public func consume(input: T) {
         
         guard let consumer = self.consumer else {
             
@@ -59,16 +59,16 @@ public final class FilterTransformer<T>: TransformerType  {
     
     public typealias OutputType = T
     
-    public var consumer: (OutputType -> Void)?
+    public var consumer: (T -> Void)?
     
-    public let condition: InputType -> Bool
+    public let condition: T -> Bool
     
-    public init(condition: InputType -> Bool) {
+    public init(condition: T -> Bool) {
         
         self.condition = condition
     }
     
-    public func consume(input: InputType) {
+    public func consume(input: T) {
         
         guard let consumer = self.consumer where condition(input) else {
                 
@@ -91,16 +91,16 @@ public final class OptionalFilterTransformer<T, U>: TransformerType  {
     
     public typealias OutputType = U
     
-    public var consumer: (OutputType -> Void)?
+    public var consumer: (U -> Void)?
     
-    public let transform: InputType -> OutputType?
+    public let transform: T -> U?
     
-    public init(transform: InputType -> OutputType?) {
+    public init(transform: T -> U?) {
         
         self.transform = transform
     }
     
-    public func consume(input: InputType) {
+    public func consume(input: T) {
         
         guard let consumer = self.consumer,
                   result = transform(input) else {
@@ -125,16 +125,16 @@ public final class PassThroughTransformer<T>: TransformerType  {
     
     public typealias OutputType = T
     
-    public var consumer: (OutputType -> Void)?
+    public var consumer: (T -> Void)?
     
-    public let observe: InputType -> Void
+    public let observe: T -> Void
     
-    public init(observe: InputType -> Void) {
+    public init(observe: T -> Void) {
         
         self.observe = observe
     }
     
-    public func consume(input: InputType) {
+    public func consume(input: T) {
         
         observe(input)
         
@@ -154,16 +154,16 @@ public final class AsyncTransformer<T, U>: TransformerType  {
     
     public typealias OutputType = U
     
-    public var consumer: (OutputType -> Void)?
+    public var consumer: (U -> Void)?
     
-    public let execute: (InputType, (OutputType -> Void)) -> Void
+    public let execute: (T, (U -> Void)) -> Void
     
-    public init(execute: (InputType, (OutputType -> Void)) -> Void) {
+    public init(execute: (T, (U -> Void)) -> Void) {
         
         self.execute = execute
     }
     
-    public func consume(input: InputType) {
+    public func consume(input: T) {
         
         guard let consumer = self.consumer else {
             

--- a/Pipeline/Transformer/Transformer.swift
+++ b/Pipeline/Transformer/Transformer.swift
@@ -24,16 +24,16 @@ public final class AnyTransformer<T, U>: TransformerType  {
     
     public typealias OutputType = U
     
-    public var consumer: (U -> Void)?
+    public var consumer: (OutputType -> Void)?
     
-    public let transform: T -> U
+    public let transform: InputType -> OutputType
     
-    public init(transform: T -> U) {
+    public init(transform: InputType -> OutputType) {
         
         self.transform = transform
     }
     
-    public func consume(input: T) {
+    public func consume(input: InputType) {
         
         guard let consumer = self.consumer else {
             
@@ -59,16 +59,16 @@ public final class FilterTransformer<T>: TransformerType  {
     
     public typealias OutputType = T
     
-    public var consumer: (T -> Void)?
+    public var consumer: (OutputType -> Void)?
     
-    public let condition: T -> Bool
+    public let condition: InputType -> Bool
     
-    public init(condition: T -> Bool) {
+    public init(condition: InputType -> Bool) {
         
         self.condition = condition
     }
     
-    public func consume(input: T) {
+    public func consume(input: InputType) {
         
         guard let consumer = self.consumer where condition(input) else {
                 
@@ -91,16 +91,16 @@ public final class OptionalFilterTransformer<T, U>: TransformerType  {
     
     public typealias OutputType = U
     
-    public var consumer: (U -> Void)?
+    public var consumer: (OutputType -> Void)?
     
-    public let transform: T -> U?
+    public let transform: InputType -> OutputType?
     
-    public init(transform: T -> U?) {
+    public init(transform: InputType -> OutputType?) {
         
         self.transform = transform
     }
     
-    public func consume(input: T) {
+    public func consume(input: InputType) {
         
         guard let consumer = self.consumer,
                   result = transform(input) else {
@@ -125,16 +125,16 @@ public final class PassThroughTransformer<T>: TransformerType  {
     
     public typealias OutputType = T
     
-    public var consumer: (T -> Void)?
+    public var consumer: (OutputType -> Void)?
     
-    public let observe: T -> Void
+    public let observe: InputType -> Void
     
-    public init(observe: T -> Void) {
+    public init(observe: InputType -> Void) {
         
         self.observe = observe
     }
     
-    public func consume(input: T) {
+    public func consume(input: InputType) {
         
         observe(input)
         
@@ -154,16 +154,16 @@ public final class AsyncTransformer<T, U>: TransformerType  {
     
     public typealias OutputType = U
     
-    public var consumer: (U -> Void)?
+    public var consumer: (OutputType -> Void)?
     
-    public let execute: (T, (U -> Void)) -> Void
+    public let execute: (InputType, (OutputType -> Void)) -> Void
     
-    public init(execute: (T, (U -> Void)) -> Void) {
+    public init(execute: (InputType, (OutputType -> Void)) -> Void) {
         
         self.execute = execute
     }
     
-    public func consume(input: T) {
+    public func consume(input: InputType) {
         
         guard let consumer = self.consumer else {
             

--- a/Pipeline/Transformer/TransformerOperators.swift
+++ b/Pipeline/Transformer/TransformerOperators.swift
@@ -8,12 +8,24 @@
 
 import Foundation
 
+// Creation
+
 public func |> <T: TransformerType, U: TransformerType where T.OutputType == U.InputType>(lhs: T, rhs: U) -> TransformerPipeline<T.InputType, U.OutputType>  {
     
     return TransformerPipeline(head: lhs).then(rhs)
 }
 
 public func |> <T: TransformerType, U>(lhs: T, rhs: T.OutputType -> U) -> TransformerPipeline<T.InputType, U>  {
+    
+    return TransformerPipeline(head: lhs).then(rhs)
+}
+
+public func |> <T: TransformerType, S, U where T.InputType == U>(lhs: S -> U, rhs: T) -> TransformerPipeline<S, T.OutputType>  {
+    
+    return TransformerPipeline(head: lhs).then(rhs)
+}
+
+public func |> <S, U, V>(lhs: S -> U, rhs: U -> V) -> TransformerPipeline<S, V>  {
     
     return TransformerPipeline(head: lhs).then(rhs)
 }
@@ -25,12 +37,7 @@ public func |> <T: TransformerType, U>(lhs: T, rhs: T.OutputType throws -> U) ->
     return TransformerPipeline(head: lhs).then(resultFunction)
 }
 
-public func |> <T: TransformerType, S, U where T.InputType == U>(lhs: S -> U, rhs: T) -> TransformerPipeline<S, T.OutputType>  {
-    
-    let transformer = AnyTransformer(transform: lhs)
-    
-    return TransformerPipeline(head: transformer).then(rhs)
-}
+// Chaining
 
 public func |> <I, O, U where U: TransformerType, O == U.InputType>(lhs: TransformerPipeline<I, O>, rhs: U) -> TransformerPipeline<I, U.OutputType>  {
     
@@ -41,6 +48,15 @@ public func |> <I, O, C>(lhs: TransformerPipeline<I, O>, rhs: O -> C) -> Transfo
     
     return lhs.then(rhs)
 }
+
+public func |> <I, O, C>(lhs: TransformerPipeline<I, O>, rhs: O throws -> C) -> TransformerPipeline<I, Result<C>>  {
+    
+    let resultFunction = map(rhs)
+    
+    return lhs.then(resultFunction)
+}
+
+// Finally
 
 public func |> <I, O, C: ConsumerType where C.InputType == O>(lhs: TransformerPipeline<I, O>, rhs: C) -> AnyConsumer<I>  {
     
@@ -55,11 +71,6 @@ public func |> <T: TransformerType>(lhs: T, rhs: T.OutputType -> Void) -> AnyCon
 public func |> <I, O>(lhs: TransformerPipeline<I, O>, rhs: O -> Void) -> AnyConsumer<I>  {
     
     return lhs.finally(rhs)
-}
-
-public func |> <S, U, V>(lhs: S -> U, rhs: U -> V) -> TransformerPipeline<S, V>  {
-    
-    return TransformerPipeline(head: lhs).then(rhs)
 }
 
 public func |> <I, O>(lhs: I -> O, rhs: O -> Void) -> AnyConsumer<I>  {

--- a/PipelineTests/ConsumableOperatorTests.swift
+++ b/PipelineTests/ConsumableOperatorTests.swift
@@ -112,15 +112,35 @@ class ConsumableOperatorTests: XCTestCase {
         waitForExpectationsWithTimeout(0.1, handler: nil)
     }
     
-    func testConsumeablePipelineConsumerFunction() {
+    func testConsumeablePipelineTransformerFunction() {
         
         let producer = ThunkProducer() { return 123 }
         
         let consumable = AnyConsumable(base: producer)
         
-        let _ = consumable |> { return $0 } |> { x in
+        let _ = consumable
+            |> AnyTransformer<Int, Int>() { return $0 }
+            |> { return $0 }
+            |> { (x: Int) in
             
             XCTAssert(x == 123)
+        }
+        
+        producer.produce()
+    }
+    
+    func testConsumeablePipelineTransformerType() {
+        
+        let producer = ThunkProducer() { return 123 }
+        
+        let consumable = AnyConsumable(base: producer)
+        
+        let _ = consumable
+            |> AnyTransformer<Int, Int>() { return $0 }
+            |> AnyTransformer<Int, Int>() { return $0 }
+            |> { (x: Int) in
+                
+                XCTAssert(x == 123)
         }
         
         producer.produce()

--- a/PipelineTests/ConsumableOperatorTests.swift
+++ b/PipelineTests/ConsumableOperatorTests.swift
@@ -129,6 +129,31 @@ class ConsumableOperatorTests: XCTestCase {
         producer.produce()
     }
     
+    func testConsumeablePipelineThrowingTransformerFunction() {
+        
+        let producer = ThunkProducer() { return 123 }
+        
+        let consumable = AnyConsumable(base: producer)
+        
+        let _ = consumable
+            |> AnyTransformer<Int, Int>() { return $0 }
+            |> { (x: Int) in return x }
+            |> { (x: Int) throws -> Int in
+                
+                throw MockError()
+                
+            } |> { (result: Result<Int>) in
+               
+                switch result{
+                    
+                case .Success(_): XCTFail()
+                default: break
+                }
+            }
+        
+        producer.produce()
+    }
+    
     func testConsumeablePipelineTransformerType() {
         
         let producer = ThunkProducer() { return 123 }

--- a/PipelineTests/HelperTests.swift
+++ b/PipelineTests/HelperTests.swift
@@ -22,9 +22,9 @@ class HelperTests: XCTestCase {
         
         let string = "abc"
         
-        let pipe = ValueProducer(string)
-            |> map() { $0.characters.count }
-            |> { count in
+        let pipe = ValueProducer<String>(string)
+            |> map() { (str: String) -> Int in str.characters.count }
+            |> { (count: Int) in
                 
                 XCTAssert(count == 3)
         }
@@ -34,7 +34,7 @@ class HelperTests: XCTestCase {
     
     func testFilter() {
         
-        let pipe = filter() { $0.characters.count == 3 }
+        let pipe = filter() { (str: String) -> Bool in str.characters.count == 3 }
             |> { (string: String) in
                 
                 XCTAssert(string.characters.count == 3)
@@ -92,7 +92,7 @@ class HelperTests: XCTestCase {
         
         let string: String? = nil
         
-        let pipe = ValueProducer(string)
+        let pipe = ValueProducer<String?>(string)
             |> guardUnwrap()
             |> { _ in XCTAssert(false) }
         
@@ -103,20 +103,20 @@ class HelperTests: XCTestCase {
         
         let string: String? = "abc"
         
-        let pipe = ValueProducer(string)
+        let pipe = ValueProducer<String?>(string)
             |> guardUnwrap()
-            |> { XCTAssert($0 == "abc") }
+            |> { (str: String) in XCTAssert(str == "abc") }
         
         pipe.produce()
     }
     
     func testGuardUnwrapWithClosure() {
         
-        let pipe = guardUnwrap() { (person: Person) in
+        let pipe = guardUnwrap() { (person: Person) -> Int? in
             
             return person.name?.characters.count
             
-        } |> { _ in XCTAssert(false) }
+            } |> { (x: Int) in XCTAssert(false) }
         
         pipe.consume(Person(name: nil))
     }
@@ -125,7 +125,7 @@ class HelperTests: XCTestCase {
         
         let string: String? = "123"
         
-        let pipe = ValueProducer(string)
+        let pipe = ValueProducer<String?>(string)
             |> forceUnwrap
             |> { (x: String) in XCTAssert(x == "123") }
         
@@ -136,8 +136,8 @@ class HelperTests: XCTestCase {
         
         let string: String? = "123"
         
-        let pipe = ValueProducer(string)
-            |> forceUnwrap { (str: String?) in return str?.characters.count }
+        let pipe = ValueProducer<String?>(string)
+            |> forceUnwrap { (str: String?) -> Int? in return str?.characters.count }
             |> { (x: Int) in x == 3  }
         
         pipe.produce()
@@ -147,9 +147,9 @@ class HelperTests: XCTestCase {
         
         let string = "123"
         
-        let pipe = ValueProducer(string)
+        let pipe = ValueProducer<String>(string)
             |> downCast(Int.self)
-            |> { _ in XCTAssert(false) }
+            |> { (x: Int) in XCTAssert(false) }
         
         pipe.produce()
     }
@@ -158,9 +158,9 @@ class HelperTests: XCTestCase {
         
         let anyObject: AnyObject = NSNumber(int: 3)
         
-        let pipe = ValueProducer(anyObject)
+        let pipe = ValueProducer<AnyObject>(anyObject)
             |> forceCast(NSNumber.self)
-            |> { x in XCTAssert(x.intValue == 3) }
+            |> { (x: NSNumber) in XCTAssert(x.intValue == 3) }
         
         pipe.produce()
     }
@@ -171,8 +171,8 @@ class HelperTests: XCTestCase {
         
         let expt = expectationWithDescription("nil")
         
-        let pipe = ValueProducer(optional)
-            |> resolveNil() { return "abc" }
+        let pipe = ValueProducer<String?>(optional)
+            |> resolveNil() { () -> String in return "abc" }
             |> { (str: String) in
                 
             XCTAssert(str == "abc")
@@ -191,8 +191,8 @@ class HelperTests: XCTestCase {
         
         let expt = expectationWithDescription("some")
         
-        let pipe = ValueProducer(optional)
-            |> resolveNil() {
+        let pipe = ValueProducer<String?>(optional)
+            |> resolveNil() { () -> String in
                 
                 XCTFail()
                 
@@ -216,8 +216,8 @@ class HelperTests: XCTestCase {
         
         let expt = expectationWithDescription("nil")
         
-        let pipe = ValueProducer(optional)
-            |> resolveNil(ThunkProducer() { return "abc" })
+        let pipe = ValueProducer<String?>(optional)
+            |> resolveNil(ThunkProducer<String>() { return "abc" })
             |> { (str: String) in
                 
                 XCTAssert(str == "abc")
@@ -236,8 +236,8 @@ class HelperTests: XCTestCase {
         
         let expt = expectationWithDescription("some")
         
-        let pipe = ValueProducer(optional)
-            |> resolveNil(ThunkProducer() {
+        let pipe = ValueProducer<String?>(optional)
+            |> resolveNil(ThunkProducer<String>() {
                 
                 XCTFail()
                 

--- a/PipelineTests/HelperTests.swift
+++ b/PipelineTests/HelperTests.swift
@@ -53,7 +53,7 @@ class HelperTests: XCTestCase {
             
             return str
         
-        } |> { (str: String) -> Int in
+        } |> { (str: String) throws -> Int in
             
             if str.characters.count == 3 {
                 

--- a/PipelineTests/HelperTests.swift
+++ b/PipelineTests/HelperTests.swift
@@ -137,7 +137,7 @@ class HelperTests: XCTestCase {
         let string: String? = "123"
         
         let pipe = ValueProducer(string)
-            |> forceUnwrap { (str: String?) in str?.characters.count }
+            |> forceUnwrap { (str: String?) in return str?.characters.count }
             |> { (x: Int) in x == 3  }
         
         pipe.produce()

--- a/PipelineTests/NSBundlePipelines.swift
+++ b/PipelineTests/NSBundlePipelines.swift
@@ -14,7 +14,7 @@ public extension NSBundle {
     
     func loadResource(name: String, fileExtension: String) -> ProducerPipeline<NSData> {
         
-        return { self.URLForResource(name, withExtension: fileExtension) }
+        return { () -> NSURL? in return self.URLForResource(name, withExtension: fileExtension) }
             |> forceUnwrap
             |> NSFileManager.loadFromURL
             |> crashOnError

--- a/PipelineTests/ProducerOperatorTests.swift
+++ b/PipelineTests/ProducerOperatorTests.swift
@@ -43,7 +43,7 @@ class ProducerOperatorTests: XCTestCase {
         let anyProducer = AnyProducer(base: ValueProducer(123))
         
         let pipe = anyProducer
-            |> { (x: Int) -> Int in return x }
+            |> integerIdentity
             |> AnyTransformer() { (x: Int) -> Int in
             
                 return x + 1
@@ -58,7 +58,7 @@ class ProducerOperatorTests: XCTestCase {
     
     func testProducerConsumerFunction() {
         
-        let pipe = ValueProducer(123) |> { x in
+        let pipe = ValueProducer(123) |> { (x: Int) in
             
             XCTAssert(x == 123)
         }
@@ -69,7 +69,7 @@ class ProducerOperatorTests: XCTestCase {
     func testProducerPipelineConsumerType() {
         
         let pipe = ValueProducer(123)
-            |> { return $0 }
+            |> integerIdentity
             |> AnyConsumer() { x in
             
             XCTAssert(x == 123)
@@ -83,7 +83,7 @@ class ProducerOperatorTests: XCTestCase {
         let expt = expectationWithDescription("error")
         
         let pipe = ValueProducer(123)
-            |> { return $0 }
+            |> integerIdentity
             |> { (x: Int) throws -> Int in
                 
                 throw MockError()
@@ -141,11 +141,11 @@ class ProducerOperatorTests: XCTestCase {
         
         let pipe = ThunkProducer() { return "abc" }
             |> throwingFunc
-            |> resolveError() {
+            |> resolveError() { () -> String in
                 
                 return "resolved"
                 
-            } |> { (str: String) in
+            } |> { (str: String) -> Void in
                 
                 XCTAssert(str == "resolved")
                 
@@ -167,7 +167,7 @@ class ProducerOperatorTests: XCTestCase {
         }
         
         let pipe = { return "abc" }
-            |> { (str: String) in return str }
+            |> stringIdentity
             |> throwingFunc
             |> resolveError() {
                 

--- a/PipelineTests/ProducerOperatorTests.swift
+++ b/PipelineTests/ProducerOperatorTests.swift
@@ -77,4 +77,30 @@ class ProducerOperatorTests: XCTestCase {
         
         pipe.produce()
     }
+    
+    func testProducerPipelineThrowingTransformerFunction() {
+        
+        let expt = expectationWithDescription("error")
+        
+        let pipe = ValueProducer(123)
+            |> { return $0 }
+            |> { (x: Int) throws -> Int in
+                
+                throw MockError()
+                
+        } |> { (result: Result<Int>) in
+        
+            switch result {
+                
+            case .Success: XCTFail()
+            default: break
+            }
+            
+            expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
 }

--- a/PipelineTests/ProducerOperatorTests.swift
+++ b/PipelineTests/ProducerOperatorTests.swift
@@ -13,12 +13,12 @@ class ProducerOperatorTests: XCTestCase {
     
     func testProducerTransformerType() {
         
-        let pipe = { return 123 } |> AnyTransformer() { x in
+        let pipe = { () -> Int in return 123 } |> AnyTransformer<Int, Int>() { (x: Int) in
             
             return x + 5
         }
         
-        pipe.consumer = { x in
+        pipe.consumer = { (x: Int) in
             
             XCTAssert(x == 128)
         }
@@ -28,9 +28,9 @@ class ProducerOperatorTests: XCTestCase {
     
     func testProducerConsumerType() {
         
-        let anyProducer = AnyProducer(base: ValueProducer(123))
+        let anyProducer = AnyProducer<Int>(base: ValueProducer<Int>(123))
         
-        let pipe = anyProducer |> AnyConsumer() { x in
+        let pipe = anyProducer |> AnyConsumer<Int>() { (x: Int) in
             
             XCTAssert(x == 123)
         }
@@ -40,11 +40,11 @@ class ProducerOperatorTests: XCTestCase {
     
     func testProducerPipelineTransformerType() {
         
-        let anyProducer = AnyProducer(base: ValueProducer(123))
+        let anyProducer = AnyProducer<Int>(base: ValueProducer<Int>(123))
         
         let pipe = anyProducer
             |> integerIdentity
-            |> AnyTransformer() { (x: Int) -> Int in
+            |> AnyTransformer<Int, Int>() { (x: Int) -> Int in
             
                 return x + 1
             
@@ -58,7 +58,7 @@ class ProducerOperatorTests: XCTestCase {
     
     func testProducerConsumerFunction() {
         
-        let pipe = ValueProducer(123) |> { (x: Int) in
+        let pipe = ValueProducer<Int>(123) |> { (x: Int) in
             
             XCTAssert(x == 123)
         }
@@ -68,9 +68,9 @@ class ProducerOperatorTests: XCTestCase {
     
     func testProducerPipelineConsumerType() {
         
-        let pipe = ValueProducer(123)
+        let pipe = ValueProducer<Int>(123)
             |> integerIdentity
-            |> AnyConsumer() { x in
+            |> AnyConsumer<Int>() { (x: Int) in
             
             XCTAssert(x == 123)
         }
@@ -82,7 +82,7 @@ class ProducerOperatorTests: XCTestCase {
         
         let expt = expectationWithDescription("error")
         
-        let pipe = ValueProducer(123)
+        let pipe = ValueProducer<Int>(123)
             |> integerIdentity
             |> { (x: Int) throws -> Int in
                 
@@ -114,7 +114,7 @@ class ProducerOperatorTests: XCTestCase {
         }
         
         let pipe = throwingFunc
-            |> resolveError() { err in
+            |> resolveError() { () -> String in
                 
                 return "resolved"
                 
@@ -139,7 +139,7 @@ class ProducerOperatorTests: XCTestCase {
             throw MockError()
         }
         
-        let pipe = ThunkProducer() { return "abc" }
+        let pipe = ThunkProducer<String>() { return "abc" }
             |> throwingFunc
             |> resolveError() { () -> String in
                 

--- a/PipelineTests/TestMocks.swift
+++ b/PipelineTests/TestMocks.swift
@@ -1,0 +1,20 @@
+//
+//  TestMocks.swift
+//  Pipeline
+//
+//  Created by Patrick Goley on 6/30/16.
+//  Copyright © 2016 arbiter. All rights reserved.
+//
+
+import Foundation
+
+
+func integerIdentity(x: Int) -> Int {
+    
+    return x
+}
+
+func stringIdentity(str: String) -> String {
+    
+    return str
+}

--- a/PipelineTests/TransformerOperatorTests.swift
+++ b/PipelineTests/TransformerOperatorTests.swift
@@ -142,4 +142,36 @@ class TransformerOperatorTests: XCTestCase {
         
         pipe.consume(inputValue)
     }
+    
+    func testTransformerPipelineThrowingFunction() {
+        
+        let expt = expectationWithDescription("error")
+        
+        let pipe = { (str: String) in return str }
+            |> AnyTransformer<String, String>() { str in return str }
+            |> { (str: String) throws -> Int in
+            
+                if str.characters.count == 3 {
+                    
+                    throw MockError()
+                    
+                } else {
+                    
+                    return str.characters.count
+                }
+                
+            } |> { (result: Result<Int>) in
+                
+                switch result {
+                case .Success(_): XCTFail()
+                default: break
+                }
+                
+                expt.fulfill()
+            }
+        
+        pipe.consume("abc")
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
 }


### PR DESCRIPTION
This fixes up a few missing `|>` overloads for various pipelines and includes related tests
