### PR TITLE
Feature/optional map

### DIFF
--- a/Pipeline.xcodeproj/project.pbxproj
+++ b/Pipeline.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		8E5E7E2F1D09FB4B007A1B7E /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E5E7E2E1D09FB4B007A1B7E /* Helpers.swift */; };
 		8E85D3801D0F8F2400B26697 /* HelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E85D37F1D0F8F2400B26697 /* HelperTests.swift */; };
 		8EB45FF31CF0D28600D0C0C4 /* Pipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB45FF21CF0D28600D0C0C4 /* Pipeline.swift */; };
+		8ECB98781D1BA523005C5EBE /* OptionalHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ECB98771D1BA523005C5EBE /* OptionalHelpers.swift */; };
+		8EDF35EA1D1BAA180099FB91 /* ErrorHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDF35E91D1BAA180099FB91 /* ErrorHandlingTests.swift */; };
 		8EE644491CE7AEA500403EFC /* Pipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EE644481CE7AEA500403EFC /* Pipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8EE644501CE7AEA500403EFC /* Pipeline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EE644451CE7AEA500403EFC /* Pipeline.framework */; };
 		8EE644641CE8600800403EFC /* ErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE644631CE8600800403EFC /* ErrorHandling.swift */; };
@@ -92,6 +94,8 @@
 		8E5E7E2E1D09FB4B007A1B7E /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		8E85D37F1D0F8F2400B26697 /* HelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelperTests.swift; sourceTree = "<group>"; };
 		8EB45FF21CF0D28600D0C0C4 /* Pipeline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pipeline.swift; sourceTree = "<group>"; };
+		8ECB98771D1BA523005C5EBE /* OptionalHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalHelpers.swift; sourceTree = "<group>"; };
+		8EDF35E91D1BAA180099FB91 /* ErrorHandlingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandlingTests.swift; sourceTree = "<group>"; };
 		8EE644451CE7AEA500403EFC /* Pipeline.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pipeline.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8EE644481CE7AEA500403EFC /* Pipeline.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Pipeline.h; sourceTree = "<group>"; };
 		8EE6444A1CE7AEA500403EFC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -187,6 +191,7 @@
 				8EF82E9A1CEAA745006FCF13 /* Operators.swift */,
 				8EB45FF21CF0D28600D0C0C4 /* Pipeline.swift */,
 				8E5E7E2E1D09FB4B007A1B7E /* Helpers.swift */,
+				8ECB98771D1BA523005C5EBE /* OptionalHelpers.swift */,
 				8EF72F191D14E039009B921F /* Execution.swift */,
 				8EE644631CE8600800403EFC /* ErrorHandling.swift */,
 				8EF8DF3A1D15B26D005BA467 /* Splitter.swift */,
@@ -203,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				8E85D37F1D0F8F2400B26697 /* HelperTests.swift */,
+				8EDF35E91D1BAA180099FB91 /* ErrorHandlingTests.swift */,
 				8E57D0F01CF516FD00EDAF4A /* JSONTests.swift */,
 				8E57D0F11CF516FD00EDAF4A /* JSONTransformers.swift */,
 				8EF72F1B1D14E0A4009B921F /* ExecutionTests.swift */,
@@ -344,6 +350,7 @@
 				8EB45FF31CF0D28600D0C0C4 /* Pipeline.swift in Sources */,
 				8E57D1251CF51E6300EDAF4A /* ConsumablePipeline.swift in Sources */,
 				8EF8DF3F1D15C20D005BA467 /* Join.swift in Sources */,
+				8ECB98781D1BA523005C5EBE /* OptionalHelpers.swift in Sources */,
 				8E5E7E2F1D09FB4B007A1B7E /* Helpers.swift in Sources */,
 				8E57D1281CF51E6300EDAF4A /* ProducerOperators.swift in Sources */,
 				8EF82E9B1CEAA745006FCF13 /* Operators.swift in Sources */,
@@ -380,6 +387,7 @@
 				8E57D1351CF52BA200EDAF4A /* TransformerTests.swift in Sources */,
 				8EF8DF411D15C7B0005BA467 /* JoinTests.swift in Sources */,
 				8E57D10C1CF516FD00EDAF4A /* TimerTests.swift in Sources */,
+				8EDF35EA1D1BAA180099FB91 /* ErrorHandlingTests.swift in Sources */,
 				8EF8DF3D1D15B3E1005BA467 /* SplitterTests.swift in Sources */,
 				8E85D3801D0F8F2400B26697 /* HelperTests.swift in Sources */,
 			);

--- a/Pipeline/Consumable/ConsumableOperators.swift
+++ b/Pipeline/Consumable/ConsumableOperators.swift
@@ -25,6 +25,20 @@ public func |> <S: ConsumableType, NewOutput>(lhs: S, rhs: S.OutputType throws -
     return ConsumablePipeline(head: lhs).then(resultFunction)
 }
 
+public func |> <S: ConsumableType, V, NewOutput where S.OutputType == Optional<V>>(lhs: S, rhs: V -> NewOutput) -> ConsumablePipeline<NewOutput?>  {
+    
+    let transformer = optionalMap(rhs)
+    
+    return ConsumablePipeline(head: lhs).then(transformer)
+}
+
+public func |> <S: ConsumableType, V, T: TransformerType where S.OutputType == Optional<V>, V == T.InputType>(lhs: S, rhs: T) -> ConsumablePipeline<T.OutputType?>  {
+    
+    let transformer = optionalMap(rhs)
+    
+    return ConsumablePipeline(head: lhs).then(transformer)
+}
+
 public func |> <S: ConsumableType, C: ConsumerType where S.OutputType == C.InputType>(lhs: S, rhs: C) -> Pipeline  {
     
     return ConsumablePipeline(head: lhs).finally(rhs)

--- a/Pipeline/Consumable/ConsumableOperators.swift
+++ b/Pipeline/Consumable/ConsumableOperators.swift
@@ -46,29 +46,6 @@ public func |> <U, NewOutput>(lhs: ConsumablePipeline<U>, rhs: U throws -> NewOu
     return lhs.then(resultFunction)
 }
 
-// optional chaining
-
-public func |> <S: ConsumableType, V, NewOutput where S.OutputType == Optional<V>>(lhs: S, rhs: V -> NewOutput) -> ConsumablePipeline<NewOutput?>  {
-    
-    let transformer = optionalMap(rhs)
-    
-    return ConsumablePipeline(head: lhs).then(transformer)
-}
-
-public func |> <S: ConsumableType, V, T: TransformerType where S.OutputType == Optional<V>, V == T.InputType>(lhs: S, rhs: T) -> ConsumablePipeline<T.OutputType?>  {
-    
-    let transformer = optionalMap(rhs)
-    
-    return ConsumablePipeline(head: lhs).then(transformer)
-}
-
-public func |> <U, NewOutput>(lhs: ConsumablePipeline<U?>, rhs: U -> NewOutput) -> ConsumablePipeline<NewOutput?>  {
-    
-    let mappedTransform = optionalMap(rhs)
-    
-    return lhs.then(mappedTransform)
-}
-
 // finally
 
 public func |> <S: ConsumableType, C: ConsumerType where S.OutputType == C.InputType>(lhs: S, rhs: C) -> Pipeline  {

--- a/Pipeline/Consumable/ConsumableOperators.swift
+++ b/Pipeline/Consumable/ConsumableOperators.swift
@@ -18,12 +18,35 @@ public func |> <S: ConsumableType, NewOutput>(lhs: S, rhs: S.OutputType -> NewOu
     return ConsumablePipeline(head: lhs).then(rhs)
 }
 
+// pipeline chaining
+
+public func |> <U, T: TransformerType where U == T.InputType>(lhs: ConsumablePipeline<U>, rhs: T) -> ConsumablePipeline<T.OutputType>  {
+    
+    return lhs.then(rhs)
+}
+
+public func |> <U, NewOutput>(lhs: ConsumablePipeline<U>, rhs: U -> NewOutput) -> ConsumablePipeline<NewOutput>  {
+    
+    return lhs.then(rhs)
+}
+
+// throwing
+
 public func |> <S: ConsumableType, NewOutput>(lhs: S, rhs: S.OutputType throws -> NewOutput) -> ConsumablePipeline<Result<NewOutput>>  {
     
     let resultFunction = map(rhs)
     
     return ConsumablePipeline(head: lhs).then(resultFunction)
 }
+
+public func |> <U, NewOutput>(lhs: ConsumablePipeline<U>, rhs: U throws -> NewOutput) -> ConsumablePipeline<Result<NewOutput>>  {
+    
+    let resultFunction = map(rhs)
+    
+    return lhs.then(resultFunction)
+}
+
+// optional chaining
 
 public func |> <S: ConsumableType, V, NewOutput where S.OutputType == Optional<V>>(lhs: S, rhs: V -> NewOutput) -> ConsumablePipeline<NewOutput?>  {
     
@@ -38,6 +61,15 @@ public func |> <S: ConsumableType, V, T: TransformerType where S.OutputType == O
     
     return ConsumablePipeline(head: lhs).then(transformer)
 }
+
+public func |> <U, NewOutput>(lhs: ConsumablePipeline<U?>, rhs: U -> NewOutput) -> ConsumablePipeline<NewOutput?>  {
+    
+    let mappedTransform = optionalMap(rhs)
+    
+    return lhs.then(mappedTransform)
+}
+
+// finally
 
 public func |> <S: ConsumableType, C: ConsumerType where S.OutputType == C.InputType>(lhs: S, rhs: C) -> Pipeline  {
     

--- a/Pipeline/ErrorHandling.swift
+++ b/Pipeline/ErrorHandling.swift
@@ -85,6 +85,29 @@ public func onError<T>(handler: (ErrorType) -> Void) -> OptionalFilterTransforme
 }
 
 /*
+ Unwraps a Result<T> value or passes the error to a closure that
+ should resolve the error and provide a value in place of the error
+ that occurred.
+ */
+
+public func resolveError<T>(resolve: (ErrorType) -> T) -> (Result<T>) -> T {
+    
+    return { result in
+
+        switch result {
+
+        case .Success(let value):
+
+            return value
+
+        case .Error(let err):
+
+            return resolve(err)
+        }
+    }
+}
+
+/*
  Unwraps a Result<T> value or causes a fatalError
 */
 

--- a/Pipeline/ErrorHandling.swift
+++ b/Pipeline/ErrorHandling.swift
@@ -108,13 +108,36 @@ public func crashOnError<T>(result: Result<T>) -> T {
  or the ErrorType that was thrown.
 */
 
-func map<T, U>(transform: (T) throws -> U) -> (T) -> Result<U> {
+public func map<T, U>(transform: (T) throws -> U) -> (T) -> Result<U> {
     
     return { input in
         
         do {
             
             let result = try transform(input)
+            
+            return .Success(result)
+            
+        } catch let err {
+            
+            return .Error(err)
+        }
+    }
+}
+
+/*
+ Produces a function that returns the result of a throwing function.
+ Produces a Result<T> which is either the resulting value of the function
+ or the ErrorType that was thrown.
+ */
+
+public func map<U>(produce: () throws -> U) -> () -> Result<U> {
+    
+    return { input in
+        
+        do {
+            
+            let result = try produce()
             
             return .Success(result)
             

--- a/Pipeline/Helpers.swift
+++ b/Pipeline/Helpers.swift
@@ -18,9 +18,9 @@ public func filter<T>(condition: (T) -> Bool) -> FilterTransformer<T> {
 }
 
 /*
- Maps a value to another value and passes it down the pipeline.
- While the transform could be used directly, this helps the compiler
- some and makes the code a bit more readable and expressive.
+ Maps a value to another value and passes it down the pipeline. While 
+ the transform function could be used directly, this makes the intent
+ explicit, making the code more readable and expressive.
 */
 
 public func map<T, U>(transform: (T) -> U) -> AnyTransformer<T, U> {
@@ -28,70 +28,6 @@ public func map<T, U>(transform: (T) -> U) -> AnyTransformer<T, U> {
     return AnyTransformer(transform: transform)
 }
 
-/*
- Unwraps optional values and filters out any nil values
-*/
-
-public func guardUnwrap<T>() -> OptionalFilterTransformer<T?, T> {
-    
-    return OptionalFilterTransformer() { $0 }
-}
-
-/*
- Unwraps optional values and invokes a closure when a nil value is encountered
- */
-
-public func onNil<T>(handler: () -> Void) -> OptionalFilterTransformer<T?, T> {
-    
-    return OptionalFilterTransformer() { (value: T?) in
-        
-        if let val = value {
-            
-            return val
-            
-        } else {
-            
-            handler()
-            
-            return nil
-        }
-    }
-}
-
-/*
- Unwraps optional values returned from a closure and filters out any nil values.
- Useful for unwrapping optional values produced through optional chaining. 
- 
- Example:
- 
- guardUnwrap() { person.employer?.name }
-*/
-
-public func guardUnwrap<T, U>(transform: T -> U?) -> OptionalFilterTransformer<T, U> {
-    
-    return OptionalFilterTransformer() { transform($0) }
-}
-
-/*
- Force unwraps an optional value. Use at your own risk.
-*/
-
-public func forceUnwrap<T>(input: T?) -> T {
-    
-    return input!
-}
-
-/*
- Force unwraps an optional value produced from a closure. Use at your own risk.
-*/
-
-public func forceUnwrap<T, U>(transform: T -> U?) -> (T -> U) {
-    
-    return {
-        
-        transform($0)!
-    }
-}
 
 /*
  Attemtps to cast incoming values to the given type, filtering out values
@@ -112,3 +48,4 @@ public func forceCast<T, U>(toType: U.Type) -> AnyTransformer<T, U> {
     
     return AnyTransformer() { $0 as! U }
 }
+

--- a/Pipeline/OptionalHelpers.swift
+++ b/Pipeline/OptionalHelpers.swift
@@ -54,27 +54,6 @@ public func forceUnwrap<T, U>(transform: T -> U?) -> (T -> U) {
 }
 
 /*
- Unwraps optional values and invokes a closure when a nil value is encountered
- */
-
-public func onNil<T>(handler: () -> Void) -> OptionalFilterTransformer<T?, T> {
-    
-    return OptionalFilterTransformer() { (value: T?) in
-        
-        if let val = value {
-            
-            return val
-            
-        } else {
-            
-            handler()
-            
-            return nil
-        }
-    }
-}
-
-/*
  Unwraps a Result<T> value or passes the error to a closure that
  should resolve the error and provide a value in place of the error
  that occurred.
@@ -91,6 +70,23 @@ public func resolveNil<T>(resolve: () -> T) -> T? -> T {
         } else {
             
             return resolve()
+        }
+    }
+}
+
+public func resolveNil<P: ProducerType, V where P.OutputType == V>(resolve: P) -> AsyncTransformer<V?, V> {
+    
+    return AsyncTransformer<V?, V>() { (input: V?, consumer: V -> Void) in
+        
+        if let value = input {
+            
+            consumer(value)
+            
+        } else {
+            
+            resolve.consumer = consumer
+            
+            resolve.produce()
         }
     }
 }

--- a/Pipeline/OptionalHelpers.swift
+++ b/Pipeline/OptionalHelpers.swift
@@ -1,0 +1,140 @@
+//
+//  OptionalHelpers.swift
+//  Pipeline
+//
+//  Created by Patrick Goley on 6/23/16.
+//  Copyright © 2016 arbiter. All rights reserved.
+//
+
+import Foundation
+
+
+/*
+ Unwraps optional values and filters out any nil values
+ */
+
+public func guardUnwrap<T>() -> OptionalFilterTransformer<T?, T> {
+    
+    return OptionalFilterTransformer() { $0 }
+}
+
+/*
+ Unwraps optional values returned from a closure and filters out any nil values.
+ Useful for unwrapping optional values produced through optional chaining.
+ 
+ Example:
+ 
+ guardUnwrap() { person in person.employer?.name }
+ */
+
+public func guardUnwrap<T, U>(transform: T -> U?) -> OptionalFilterTransformer<T, U> {
+    
+    return OptionalFilterTransformer() { transform($0) }
+}
+
+/*
+ Force unwraps an optional value. Use at your own risk.
+ */
+
+public func forceUnwrap<T>(input: T?) -> T {
+    
+    return input!
+}
+
+/*
+ Force unwraps an optional value produced from a closure. Use at your own risk.
+ */
+
+public func forceUnwrap<T, U>(transform: T -> U?) -> (T -> U) {
+    
+    return {
+        
+        transform($0)!
+    }
+}
+
+/*
+ Unwraps optional values and invokes a closure when a nil value is encountered
+ */
+
+public func onNil<T>(handler: () -> Void) -> OptionalFilterTransformer<T?, T> {
+    
+    return OptionalFilterTransformer() { (value: T?) in
+        
+        if let val = value {
+            
+            return val
+            
+        } else {
+            
+            handler()
+            
+            return nil
+        }
+    }
+}
+
+/*
+ Unwraps a Result<T> value or passes the error to a closure that
+ should resolve the error and provide a value in place of the error
+ that occurred.
+ */
+
+public func resolveNil<T>(resolve: () -> T) -> T? -> T {
+    
+    return { optional in
+        
+        if let value = optional {
+            
+            return value
+            
+        } else {
+            
+            return resolve()
+        }
+    }
+}
+
+/*
+ Creates a function that attempts to unwrap and optional and apply a transform.
+ Returns nil if nil is encountered. This mirrors the effect of optional
+ chaining in dot notation. For example:
+ 
+ `person.employer?.name` results in `String?`
+ 
+ `() -> Employer? |> optionalMap(Employer -> String)` results in `() -> String?`
+ 
+ */
+
+public func optionalMap<T, U>(transform: T -> U) -> T? -> U? {
+    
+    return { input in
+        
+        if let value = input {
+            
+            return transform(value)
+        }
+        
+        return nil
+    }
+}
+
+public func optionalMap<T: TransformerType, U, V where T.InputType == U, T.OutputType == V>(transformer: T) -> AsyncTransformer<U?, V?> {
+    
+    return AsyncTransformer() { input, consumer in
+        
+        if let value = input {
+            
+            transformer.consumer = consumer
+            
+            transformer.consume(value)
+            
+        } else {
+            
+            consumer(nil)
+        }
+    }
+}
+
+
+

--- a/Pipeline/Pipeline.swift
+++ b/Pipeline/Pipeline.swift
@@ -17,3 +17,4 @@ import Foundation
 */
 
 public class Pipeline { }
+

--- a/Pipeline/Producer/ProducerOperators.swift
+++ b/Pipeline/Producer/ProducerOperators.swift
@@ -79,33 +79,6 @@ public func |> <V, T>(lhs: () throws -> V, rhs: Result<V> -> T) -> ProducerPipel
     return ProducerPipeline(head: producer).then(rhs)
 }
 
-// optional chaining
-
-public func |> <P: ProducerType, V, NewOutput where P.OutputType == Optional<V>>(lhs: P, rhs: V -> NewOutput) -> ProducerPipeline<NewOutput?>  {
-    
-    let mappedTransform = optionalMap(rhs)
-    
-    return ProducerPipeline(head: lhs).then(mappedTransform)
-}
-
-public func |> <V, T: TransformerType where V == T.InputType>(lhs: () -> V?, rhs: T) -> ProducerPipeline<T.OutputType?>  {
-    
-    let producer = ThunkProducer(thunk: lhs)
-    
-    let mappedTransformer = optionalMap(rhs)
-    
-    return ProducerPipeline(head: producer).then(mappedTransformer)
-}
-
-public func |> <V, T>(lhs: () -> V?, rhs: V -> T) -> ProducerPipeline<T?>  {
-    
-    let thunkProducer = ThunkProducer(thunk: lhs)
-    
-    let mappedTransform = optionalMap(rhs)
-    
-    return ProducerPipeline(head: thunkProducer).then(mappedTransform)
-}
-
 // finally
 
 public func |> <P: ProducerType>(lhs: P, rhs: P.OutputType -> Void) -> Producible  {

--- a/Pipeline/Producer/ProducerOperators.swift
+++ b/Pipeline/Producer/ProducerOperators.swift
@@ -16,14 +16,7 @@ public func |> <P: ProducerType, U: TransformerType where P.OutputType == U.Inpu
 
 public func |> <P: ProducerType, U>(lhs: P, rhs: P.OutputType -> U) -> ProducerPipeline<U>  {
     
-    let pipe = ProducerPipeline(head: lhs)
-    
-    return pipe.then(rhs)
-}
-
-public func |> <O, T where T: TransformerType, O == T.InputType>(lhs: ProducerPipeline<O>, rhs: T) -> ProducerPipeline<T.OutputType>  {
-    
-    return lhs.then(rhs)
+    return ProducerPipeline(head: lhs).then(rhs)
 }
 
 public func |> <V, T: TransformerType where V == T.InputType>(lhs: () -> V, rhs: T) -> ProducerPipeline<T.OutputType>  {
@@ -40,15 +33,80 @@ public func |> <V, T>(lhs: () -> V, rhs: V -> T) -> ProducerPipeline<T>  {
     return ProducerPipeline(head: thunkProducer).then(rhs)
 }
 
+// pipeline chaining
+
 public func |> <O, C>(lhs: ProducerPipeline<O>, rhs: O -> C) -> ProducerPipeline<C>  {
     
     return lhs.then(rhs)
 }
 
-public func |> <P: ProducerType, C: ConsumerType where C.InputType == P.OutputType>(lhs: P, rhs: C) -> Producible  {
+public func |> <O, T where T: TransformerType, O == T.InputType>(lhs: ProducerPipeline<O>, rhs: T) -> ProducerPipeline<T.OutputType>  {
     
-    return ProducerPipeline(head: lhs).finally(rhs)
+    return lhs.then(rhs)
 }
+
+// throwing
+
+public func |> <P: ProducerType, U>(lhs: P, rhs: P.OutputType throws -> U) -> ProducerPipeline<Result<U>>  {
+    
+    let throwingTransform = map(rhs)
+    
+    return ProducerPipeline(head: lhs).then(throwingTransform)
+}
+
+public func |> <O, C>(lhs: ProducerPipeline<O>, rhs: O throws -> C) -> ProducerPipeline<Result<C>>  {
+    
+    let throwingTransform = map(rhs)
+    
+    return lhs.then(throwingTransform)
+}
+
+public func |> <V, T: TransformerType where T.InputType == Result<V>>(lhs: () throws -> V, rhs: T) -> ProducerPipeline<T.OutputType>  {
+    
+    let throwingProduce = map(lhs)
+    
+    let producer = ThunkProducer(thunk: throwingProduce)
+    
+    return ProducerPipeline(head: producer).then(rhs)
+}
+
+public func |> <V, T>(lhs: () throws -> V, rhs: Result<V> -> T) -> ProducerPipeline<T>  {
+    
+    let throwingProduce = map(lhs)
+    
+    let producer = ThunkProducer(thunk: throwingProduce)
+    
+    return ProducerPipeline(head: producer).then(rhs)
+}
+
+// optional chaining
+
+public func |> <P: ProducerType, V, NewOutput where P.OutputType == Optional<V>>(lhs: P, rhs: V -> NewOutput) -> ProducerPipeline<NewOutput?>  {
+    
+    let mappedTransform = optionalMap(rhs)
+    
+    return ProducerPipeline(head: lhs).then(mappedTransform)
+}
+
+public func |> <V, T: TransformerType where V == T.InputType>(lhs: () -> V?, rhs: T) -> ProducerPipeline<T.OutputType?>  {
+    
+    let producer = ThunkProducer(thunk: lhs)
+    
+    let mappedTransformer = optionalMap(rhs)
+    
+    return ProducerPipeline(head: producer).then(mappedTransformer)
+}
+
+public func |> <V, T>(lhs: () -> V?, rhs: V -> T) -> ProducerPipeline<T?>  {
+    
+    let thunkProducer = ThunkProducer(thunk: lhs)
+    
+    let mappedTransform = optionalMap(rhs)
+    
+    return ProducerPipeline(head: thunkProducer).then(mappedTransform)
+}
+
+// finally
 
 public func |> <P: ProducerType>(lhs: P, rhs: P.OutputType -> Void) -> Producible  {
     
@@ -63,5 +121,10 @@ public func |> <O, C: ConsumerType where C.InputType == O>(lhs: ProducerPipeline
 public func |> <O>(lhs: ProducerPipeline<O>, rhs: O -> Void) -> Producible  {
     
     return lhs.finally(rhs)
+}
+
+public func |> <P: ProducerType, C: ConsumerType where C.InputType == P.OutputType>(lhs: P, rhs: C) -> Producible  {
+    
+    return ProducerPipeline(head: lhs).finally(rhs)
 }
 

--- a/Pipeline/Transformer/Transformer.swift
+++ b/Pipeline/Transformer/Transformer.swift
@@ -80,47 +80,6 @@ public final class FilterTransformer<T>: TransformerType  {
 }
 
 /*
- A function that attempts to unwrap and optional and apply a transform.
- Returns nil if nil is encountered. This mirrors the effect of optional
- chaining in dot notation. For example:
- 
- `person.employer?.name` results in `String?`
- 
- `() -> Employer? |> optionalMap(Employer -> String)` results in `() -> S?`
- 
- */
-
-func optionalMap<T, U>(transform: T -> U) -> T? -> U? {
-    
-    return { input in
-        
-        if let value = input {
-            
-            return transform(value)
-        }
-        
-        return nil
-    }
-}
-
-func optionalMap<T: TransformerType, U, V where T.InputType == U, T.OutputType == V>(transformer: T) -> AsyncTransformer<U?, V?> {
-    
-    return AsyncTransformer() { input, consumer in
-        
-        if let value = input {
-            
-            transformer.consumer = consumer
-            
-            transformer.consume(value)
-            
-        } else {
-            
-            consumer(nil)
-        }
-    }
-}
-
-/*
  A transformer that attempts to unwrap optionals and pass along
  the unwrapped valued. If nil is encountered, the execution of the
  Pipeline ends (no value is passed to the consumer).

--- a/Pipeline/Transformer/TransformerOperators.swift
+++ b/Pipeline/Transformer/TransformerOperators.swift
@@ -18,13 +18,6 @@ public func |> <T: TransformerType, U>(lhs: T, rhs: T.OutputType -> U) -> Transf
     return TransformerPipeline(head: lhs).then(rhs)
 }
 
-public func |> <T: TransformerType, U>(lhs: T, rhs: T.OutputType throws -> U) -> TransformerPipeline<T.InputType, Result<U>>  {
-    
-    let resultFunction = map(rhs)
-    
-    return TransformerPipeline(head: lhs).then(resultFunction)
-}
-
 public func |> <T: TransformerType, S, U where T.InputType == U>(lhs: S -> U, rhs: T) -> TransformerPipeline<S, T.OutputType>  {
     
     let transformer = AnyTransformer(transform: lhs)
@@ -42,24 +35,25 @@ public func |> <I, O, C>(lhs: TransformerPipeline<I, O>, rhs: O -> C) -> Transfo
     return lhs.then(rhs)
 }
 
-public func |> <I, O, C: ConsumerType where C.InputType == O>(lhs: TransformerPipeline<I, O>, rhs: C) -> AnyConsumer<I>  {
+public func |> <S, U, V>(lhs: S -> U, rhs: U -> V) -> TransformerPipeline<S, V>  {
     
-    return lhs.finally(rhs)
+    return TransformerPipeline(head: lhs).then(rhs)
 }
+
+// throwing
+
+public func |> <T: TransformerType, U>(lhs: T, rhs: T.OutputType throws -> U) -> TransformerPipeline<T.InputType, Result<U>>  {
+    
+    let resultFunction = map(rhs)
+    
+    return TransformerPipeline(head: lhs).then(resultFunction)
+}
+
+// finally
 
 public func |> <T: TransformerType>(lhs: T, rhs: T.OutputType -> Void) -> AnyConsumer<T.InputType>  {
     
     return TransformerPipeline(head: lhs).finally(rhs)
-}
-
-public func |> <I, O>(lhs: TransformerPipeline<I, O>, rhs: O -> Void) -> AnyConsumer<I>  {
-    
-    return lhs.finally(rhs)
-}
-
-public func |> <S, U, V>(lhs: S -> U, rhs: U -> V) -> TransformerPipeline<S, V>  {
-    
-    return TransformerPipeline(head: lhs).then(rhs)
 }
 
 public func |> <I, O>(lhs: I -> O, rhs: O -> Void) -> AnyConsumer<I>  {
@@ -74,5 +68,15 @@ public func |> <I, O, C: ConsumerType where C.InputType == O>(lhs: I -> O, rhs: 
     let pipeline = TransformerPipeline(head: lhs)
     
     return pipeline.finally(rhs)
+}
+
+public func |> <I, O, C: ConsumerType where C.InputType == O>(lhs: TransformerPipeline<I, O>, rhs: C) -> AnyConsumer<I>  {
+    
+    return lhs.finally(rhs)
+}
+
+public func |> <I, O>(lhs: TransformerPipeline<I, O>, rhs: O -> Void) -> AnyConsumer<I>  {
+    
+    return lhs.finally(rhs)
 }
 

--- a/PipelineTests/ConsumableOperatorTests.swift
+++ b/PipelineTests/ConsumableOperatorTests.swift
@@ -69,7 +69,41 @@ class ConsumableOperatorTests: XCTestCase {
         
         let consumable = AnyConsumable(base: producer)
         
-        let _ = consumable |> { return $0 } |> AnyConsumer() { x in
+        let pipe = ConsumablePipeline(head: consumable)
+        
+        let _ = pipe |> { return $0 } |> AnyTransformer() { $0 } |> AnyConsumer() { x in
+            
+            XCTAssert(x == 123)
+        }
+        
+        producer.produce()
+    }
+    
+    func testConsumeablePipelineConsumerFunction() {
+        
+        let producer = ThunkProducer() { return 123 }
+        
+        let consumable = AnyConsumable(base: producer)
+        
+        let pipe = ConsumablePipeline(head: consumable)
+        
+        let _ = pipe |> { return $0 } |> AnyConsumer() { x in
+            
+            XCTAssert(x == 123)
+        }
+        
+        producer.produce()
+    }
+    
+    func testConsumeablePipelineTransformerType() {
+        
+        let producer = ThunkProducer() { return 123 }
+        
+        let consumable = AnyConsumable(base: producer)
+        
+        let pipe = ConsumablePipeline(head: consumable)
+        
+        let _ = pipe |> AnyTransformer() { $0 } |> AnyConsumer() { x in
             
             XCTAssert(x == 123)
         }
@@ -110,20 +144,6 @@ class ConsumableOperatorTests: XCTestCase {
         producer.produce()
         
         waitForExpectationsWithTimeout(0.1, handler: nil)
-    }
-    
-    func testConsumeablePipelineConsumerFunction() {
-        
-        let producer = ThunkProducer() { return 123 }
-        
-        let consumable = AnyConsumable(base: producer)
-        
-        let _ = consumable |> { return $0 } |> { x in
-            
-            XCTAssert(x == 123)
-        }
-        
-        producer.produce()
     }
     
     func testConsumeableOptionalMap() {

--- a/PipelineTests/ConsumableOperatorTests.swift
+++ b/PipelineTests/ConsumableOperatorTests.swift
@@ -152,7 +152,7 @@ class ConsumableOperatorTests: XCTestCase {
         
         let expt = expectationWithDescription("nil")
         
-        let pipe = producer |> { (int: Int) in int + 5 }
+        let pipe = producer |> optionalMap({ (int: Int) in int + 5 })
         
         pipe.consumer = { (x: Int?) in
             
@@ -172,7 +172,7 @@ class ConsumableOperatorTests: XCTestCase {
         
         let expt = expectationWithDescription("value")
         
-        let pipe = producer |> { (int: Int) in int + 5 }
+        let pipe = producer |> optionalMap({ (int: Int) in int + 5 })
         
         pipe.consumer = { (x: Int?) in
             
@@ -199,7 +199,7 @@ class ConsumableOperatorTests: XCTestCase {
         
         let expt = expectationWithDescription("nil")
         
-        let pipe = producer |> AnyTransformer() { (int: Int) in int + 5 }
+        let pipe = producer |> optionalMap(AnyTransformer() { (int: Int) in int + 5 })
         
         pipe.consumer = { (x: Int?) in
             
@@ -219,7 +219,7 @@ class ConsumableOperatorTests: XCTestCase {
         
         let expt = expectationWithDescription("value")
         
-        let pipe = producer |> AnyTransformer() { (int: Int) in int + 5 }
+        let pipe = producer |> optionalMap(AnyTransformer() { (int: Int) in int + 5 })
         
         pipe.consumer = { (x: Int?) in
             

--- a/PipelineTests/ConsumableOperatorTests.swift
+++ b/PipelineTests/ConsumableOperatorTests.swift
@@ -125,4 +125,98 @@ class ConsumableOperatorTests: XCTestCase {
         
         producer.produce()
     }
+    
+    func testConsumeableOptionalMap() {
+        
+        let producer = ThunkProducer<Int?>() { return nil }
+        
+        let expt = expectationWithDescription("nil")
+        
+        let pipe = producer |> { (int: Int) in int + 5 }
+        
+        pipe.consumer = { (x: Int?) in
+            
+            XCTAssertNil(x)
+            
+            expt.fulfill()
+        }
+        
+        producer.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testConsumeableOptionalMapWithValue() {
+        
+        let producer = ThunkProducer<Int?>() { return 123 }
+        
+        let expt = expectationWithDescription("value")
+        
+        let pipe = producer |> { (int: Int) in int + 5 }
+        
+        pipe.consumer = { (x: Int?) in
+            
+            if let val = x {
+                
+                XCTAssert(val == 128)
+                
+            } else {
+                
+                XCTFail()
+            }
+            
+            expt.fulfill()
+        }
+        
+        producer.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testConsumeableTransformerOptionalMap() {
+        
+        let producer = ThunkProducer<Int?>() { return nil }
+        
+        let expt = expectationWithDescription("nil")
+        
+        let pipe = producer |> AnyTransformer() { (int: Int) in int + 5 }
+        
+        pipe.consumer = { (x: Int?) in
+            
+            XCTAssertNil(x)
+            
+            expt.fulfill()
+        }
+        
+        producer.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testConsumeableTransformerOptionalMapWithValue() {
+        
+        let producer = ThunkProducer<Int?>() { return 123 }
+        
+        let expt = expectationWithDescription("value")
+        
+        let pipe = producer |> AnyTransformer() { (int: Int) in int + 5 }
+        
+        pipe.consumer = { (x: Int?) in
+            
+            if let val = x {
+                
+                XCTAssert(val == 128)
+                
+            } else {
+                
+                XCTFail()
+            }
+            
+            expt.fulfill()
+        }
+        
+        producer.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
 }

--- a/PipelineTests/ErrorHandlingTests.swift
+++ b/PipelineTests/ErrorHandlingTests.swift
@@ -1,0 +1,140 @@
+//
+//  ErrorHandlingTests.swift
+//  Pipeline
+//
+//  Created by Patrick Goley on 6/23/16.
+//  Copyright © 2016 arbiter. All rights reserved.
+//
+
+import XCTest
+import Pipeline
+
+class ErrorHandlingTests: XCTestCase {
+
+    func testSwallowError() {
+        
+        let result: Result<String> = .Error(MockError())
+        
+        let pipe = ValueProducer(result)
+            |> swallowError(log: "found error")
+            |> { _ in XCTAssert(false) }
+        
+        pipe.produce()
+    }
+    
+    func testSwallowErrorSuccess() {
+        
+        let result: Result<String> = .Success("abc")
+        
+        let expt = expectationWithDescription("error")
+        
+        let pipe = ValueProducer(result)
+            |> swallowError(log: "found error")
+            |> { (str: String) in
+                
+                XCTAssert(str == "abc")
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testLogError() {
+        
+        let result: Result<String> = .Error(MockError())
+        
+        let pipe = ValueProducer(result)
+            |> logError("found error")
+            |> { _ in XCTAssert(false) }
+        
+        pipe.produce()
+    }
+    
+    func testLogErrorSuccess() {
+        
+        let result: Result<String> = .Success("abc")
+        
+        let expt = expectationWithDescription("error")
+        
+        let pipe = ValueProducer(result)
+            |> logError("found error")
+            |> { (str: String) in
+                
+                XCTAssert(str == "abc")
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testOnError() {
+        
+        let result: Result<String> = .Error(MockError())
+        
+        let expt = expectationWithDescription("error")
+        
+        let pipe = ValueProducer(result) |> onError() { err in
+            
+            XCTAssert(err is MockError)
+            
+            expt.fulfill()
+            
+            } |> { (str: String) in
+                
+                XCTFail()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testOnErrorSuccess() {
+        
+        let result: Result<String> = .Success("success")
+        
+        let expt = expectationWithDescription("error")
+        
+        let pipe = ValueProducer(result) |> onError() { err in
+            
+            XCTFail()
+            
+            } |> { (str: String) in
+                
+                XCTAssert(str == "success")
+                
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testResolveError() {
+        
+        let result: Result<String> = .Error(MockError())
+        
+        let expt = expectationWithDescription("error")
+        
+        let pipe = ValueProducer(result)
+            |> resolveError() { err in
+                
+                return "resolved"
+                
+            } |> { (str: String) in
+                
+                XCTAssert(str == "resolved")
+                
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+}

--- a/PipelineTests/HelperTests.swift
+++ b/PipelineTests/HelperTests.swift
@@ -165,48 +165,6 @@ class HelperTests: XCTestCase {
         pipe.produce()
     }
     
-    func testOnNil() {
-        
-        let optional: String? = nil
-        
-        let expt = expectationWithDescription("nil")
-        
-        let pipe = ValueProducer(optional) |> onNil() {
-            
-            expt.fulfill()
-            
-        } |> { (str: String) in
-                
-            XCTFail()
-        }
-        
-        pipe.produce()
-        
-        waitForExpectationsWithTimeout(0.1, handler: nil)
-    }
-    
-    func testOnNilSome() {
-        
-        let optional: String? = "some"
-        
-        let expt = expectationWithDescription("nil")
-        
-        let pipe = ValueProducer(optional) |> onNil() {
-            
-            XCTFail()
-            
-            } |> { (str: String) in
-                
-                XCTAssert(str == "some")
-                
-                expt.fulfill()
-        }
-        
-        pipe.produce()
-        
-        waitForExpectationsWithTimeout(0.1, handler: nil)
-    }
-    
     func testResolveNil() {
         
         let optional: String? = nil
@@ -241,6 +199,51 @@ class HelperTests: XCTestCase {
                 return ""
                 
             } |> { (str: String) in
+                
+                XCTAssert(str == "abc")
+                
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testResolveNilProducer() {
+        
+        let optional: String? = nil
+        
+        let expt = expectationWithDescription("nil")
+        
+        let pipe = ValueProducer(optional)
+            |> resolveNil(ThunkProducer() { return "abc" })
+            |> { (str: String) in
+                
+                XCTAssert(str == "abc")
+                
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testResolveNilProducerSome() {
+        
+        let optional: String? = "abc"
+        
+        let expt = expectationWithDescription("some")
+        
+        let pipe = ValueProducer(optional)
+            |> resolveNil(ThunkProducer() {
+                
+                XCTFail()
+                
+                return ""
+                
+            }) |> { (str: String) in
                 
                 XCTAssert(str == "abc")
                 

--- a/PipelineTests/HelperTests.swift
+++ b/PipelineTests/HelperTests.swift
@@ -165,110 +165,6 @@ class HelperTests: XCTestCase {
         pipe.produce()
     }
     
-    func testSwallowError() {
-        
-        let result: Result<String> = .Error(MockError())
-        
-        let pipe = ValueProducer(result)
-            |> swallowError(log: "found error")
-            |> { _ in XCTAssert(false) }
-        
-        pipe.produce()
-    }
-    
-    func testSwallowErrorSuccess() {
-        
-        let result: Result<String> = .Success("abc")
-        
-        let expt = expectationWithDescription("error")
-        
-        let pipe = ValueProducer(result)
-            |> swallowError(log: "found error")
-            |> { (str: String) in
-                
-                XCTAssert(str == "abc")
-                expt.fulfill()
-        }
-        
-        pipe.produce()
-        
-        waitForExpectationsWithTimeout(0.1, handler: nil)
-    }
-    
-    func testLogError() {
-        
-        let result: Result<String> = .Error(MockError())
-        
-        let pipe = ValueProducer(result)
-            |> logError("found error")
-            |> { _ in XCTAssert(false) }
-        
-        pipe.produce()
-    }
-    
-    func testLogErrorSuccess() {
-        
-        let result: Result<String> = .Success("abc")
-        
-        let expt = expectationWithDescription("error")
-        
-        let pipe = ValueProducer(result)
-            |> logError("found error")
-            |> { (str: String) in
-                
-                XCTAssert(str == "abc")
-                expt.fulfill()
-        }
-        
-        pipe.produce()
-        
-        waitForExpectationsWithTimeout(0.1, handler: nil)
-    }
-    
-    func testOnError() {
-        
-        let result: Result<String> = .Error(MockError())
-        
-        let expt = expectationWithDescription("error")
-        
-        let pipe = ValueProducer(result) |> onError() { err in
-                
-                XCTAssert(err is MockError)
-                
-                expt.fulfill()
-            
-        } |> { (str: String) in
-            
-            XCTFail()
-        }
-        
-        pipe.produce()
-        
-        waitForExpectationsWithTimeout(0.1, handler: nil)
-    }
-    
-    func testOnErrorSuccess() {
-        
-        let result: Result<String> = .Success("success")
-        
-        let expt = expectationWithDescription("error")
-        
-        let pipe = ValueProducer(result) |> onError() { err in
-            
-            XCTFail()
-            
-        } |> { (str: String) in
-                
-            XCTAssert(str == "success")
-            
-            expt.fulfill()
-        }
-        
-        pipe.produce()
-        
-        waitForExpectationsWithTimeout(0.1, handler: nil)
-    }
-    
     func testOnNil() {
         
         let optional: String? = nil
@@ -282,6 +178,26 @@ class HelperTests: XCTestCase {
         } |> { (str: String) in
                 
             XCTFail()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testResolveNil() {
+        
+        let optional: String? = nil
+        
+        let expt = expectationWithDescription("nil")
+        
+        let pipe = ValueProducer(optional)
+            |> resolveNil() { return "abc" }
+            |> { (str: String) in
+                
+            XCTAssert(str == "abc")
+            
+            expt.fulfill()
         }
         
         pipe.produce()

--- a/PipelineTests/HelperTests.swift
+++ b/PipelineTests/HelperTests.swift
@@ -185,6 +185,28 @@ class HelperTests: XCTestCase {
         waitForExpectationsWithTimeout(0.1, handler: nil)
     }
     
+    func testOnNilSome() {
+        
+        let optional: String? = "some"
+        
+        let expt = expectationWithDescription("nil")
+        
+        let pipe = ValueProducer(optional) |> onNil() {
+            
+            XCTFail()
+            
+            } |> { (str: String) in
+                
+                XCTAssert(str == "some")
+                
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
     func testResolveNil() {
         
         let optional: String? = nil
@@ -205,21 +227,24 @@ class HelperTests: XCTestCase {
         waitForExpectationsWithTimeout(0.1, handler: nil)
     }
     
-    func testOnNilSome() {
+    func testResolveNilSome() {
         
-        let optional: String? = "some"
+        let optional: String? = "abc"
         
-        let expt = expectationWithDescription("nil")
+        let expt = expectationWithDescription("some")
         
-        let pipe = ValueProducer(optional) |> onNil() {
-            
-            XCTFail()
-            
-        } |> { (str: String) in
-            
-            XCTAssert(str == "some")
-            
-            expt.fulfill()
+        let pipe = ValueProducer(optional)
+            |> resolveNil() {
+                
+                XCTFail()
+                
+                return ""
+                
+            } |> { (str: String) in
+                
+                XCTAssert(str == "abc")
+                
+                expt.fulfill()
         }
         
         pipe.produce()

--- a/PipelineTests/ProducerOperatorTests.swift
+++ b/PipelineTests/ProducerOperatorTests.swift
@@ -77,4 +77,85 @@ class ProducerOperatorTests: XCTestCase {
         
         pipe.produce()
     }
+    
+    func testThrowingProducerFunction() {
+        
+        let expt = expectationWithDescription("error")
+        
+        let throwingFunc: () throws -> String = {
+            
+            throw MockError()
+        }
+        
+        let pipe = throwingFunc
+            |> resolveError() { err in
+                
+                return "resolved"
+                
+            } |> { (str: String) in
+                
+                XCTAssert(str == "resolved")
+                
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testProducerThrowingFunction() {
+        
+        let expt = expectationWithDescription("error")
+        
+        let throwingFunc: String throws -> String = { str in
+            
+            throw MockError()
+        }
+        
+        let pipe = ThunkProducer() { return "abc" }
+            |> throwingFunc
+            |> resolveError() {
+                
+                return "resolved"
+                
+            } |> { (str: String) in
+                
+                XCTAssert(str == "resolved")
+                
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    func testProducerPipelineThrowingFunction() {
+        
+        let expt = expectationWithDescription("error")
+        
+        let throwingFunc: String throws -> String = { str in
+            
+            throw MockError()
+        }
+        
+        let pipe = { return "abc" }
+            |> { (str: String) in return str }
+            |> throwingFunc
+            |> resolveError() {
+                
+                return "resolved"
+                
+            } |> { (str: String) in
+                
+                XCTAssert(str == "resolved")
+                
+                expt.fulfill()
+        }
+        
+        pipe.produce()
+        
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
 }

--- a/PipelineTests/TransformerOperatorTests.swift
+++ b/PipelineTests/TransformerOperatorTests.swift
@@ -125,7 +125,8 @@ class TransformerOperatorTests: XCTestCase {
     
     func testTransformerFunctionConsumerFunction() {
         
-        let pipe = { (x: Int) in return "\(x)" } |> { (x: String) in
+        let pipe = { (x: Int) in return "\(x)" }
+            |> { (x: String) in
             
             XCTAssert(x == "321")
         }

--- a/PipelineTests/TransformerOperatorTests.swift
+++ b/PipelineTests/TransformerOperatorTests.swift
@@ -143,4 +143,32 @@ class TransformerOperatorTests: XCTestCase {
         
         pipe.consume(inputValue)
     }
+    
+    func testThrowingFunctionTransformerType() {
+        
+        let throwingProducer: () throws -> String = {
+            
+            throw MockError()
+        }
+            
+        let pipe = throwingProducer
+            |> AnyTransformer() { (result: Result<String>) -> String in
+                
+            switch result {
+                
+            case .Success(let str):
+                XCTFail()
+                return str
+            default: break
+            }
+                
+            return ""
+                
+        } |> { (str: String) in
+                    
+            print(str)
+        }
+        
+        pipe.produce()
+    }
 }


### PR DESCRIPTION
This allows functions or types to be wrapped with a call to optionalMap such that the following is true:

() -> T? chained with optionalMap(T -> U) results in () -> U?
This is a similar effect to optional chaining with dot notation and adds flexibility in that non-optional taking type can be chained to optional producing types and simply propagate nil values down the pipeline. This is contrary to guardUnwrap which stops execution on nil values and resolveNil which provides a fall back value in place of nil.

Opted for a helper function to create compatible types out of incompatible types instead of providing more overloads for |> that did the same for three reasons:
1. Explicit helper makes the intention obvious to others and the compiler.
2. There would be many more required overloads to make this use case transparent which would hurt compile times.
3. Users may not realized they've chained to an optional if it happens transparently.
